### PR TITLE
更新popup.html以解决弹出页无法弹出的问题

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -77,7 +77,7 @@
   
   <footer>
     <div class="setting-button link" id="setting-button" title="设置"></div>
-    Powered By <img src="http://www.youdao.com/help/fanyiapi/brand/002.gif" alt="有道翻译">
+    Powered By 有道翻译
     <div class="contact-info">
       <span id="score" class="link" title="亲，给个好评吧:)"></span>
       <span id="email" class="link" title="如有问题可以发邮件"></span>


### PR DESCRIPTION
因popup.html中http://www.youdao.com/help/fanyiapi/brand/002.gif 无法访问导致弹出页以及插件无法正常使用。将图片显示更换为文字。